### PR TITLE
Remove HEAD from limit_except directive in nginx conf files.

### DIFF
--- a/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
@@ -73,7 +73,7 @@ server {
     }
 
     location /limitget/ {
-        limit_except GET HEAD {
+        limit_except GET {
             deny all;
         }
         proxy_pass http://other/;

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -82,7 +82,7 @@
             - name: limitget
               location: /limitget/
               server: http://other/
-              limit_methods: GET HEAD
+              limit_methods: GET
           nginx_proxy_additional_directives:
             - "add_header Access-Control-Allow-Origin $allow_origin"
             - "location = /testing/additional/block { return 404; }"


### PR DESCRIPTION
Removing unnecessary http method. HEAD is implicit when GET is present.

For further reading about this from the nginx docs: <http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except>