### PR TITLE
Fix SELinux cache permissions

### DIFF
--- a/tasks/nginx-cache.yml
+++ b/tasks/nginx-cache.yml
@@ -13,7 +13,7 @@
 - name: nginx | fix cache directory permissions
   become: true
   file:
-    dest: /var/cache/nginx
+    dest: "{{ nginx_proxy_cache_parent_path }}"
     group: nginx
     mode: 0750
     owner: nginx

--- a/tasks/nginx-selinux.yml
+++ b/tasks/nginx-selinux.yml
@@ -17,3 +17,23 @@
     setype: http_port_t
     state: present
   with_items: "{{ nginx_proxy_streams }}"
+
+# /etc/selinux/targeted/contexts/files/file_contexts is missing
+# /var/cache/nginx(/.*)? so Nginx may not be able to  modify the cache
+- name: nginx | selinux cache context policy
+  become: true
+  sefcontext:
+    target: >-
+      {{ nginx_proxy_cache_parent_path | regex_replace('\\/$', '') }}(/.*)?
+    setype: httpd_cache_t
+    state: present
+
+- name: nginx | restore cache context
+  become: true
+  command: >-
+    /usr/sbin/restorecon -R -v
+    {{ ansible_check_mode | ternary('-n', '') }}
+    {{ nginx_proxy_cache_parent_path }}
+  register: result
+  check_mode: false
+  changed_when: 'result.stdout != ""'

--- a/tasks/nginx-selinux.yml
+++ b/tasks/nginx-selinux.yml
@@ -19,7 +19,7 @@
   with_items: "{{ nginx_proxy_streams }}"
 
 # /etc/selinux/targeted/contexts/files/file_contexts is missing
-# /var/cache/nginx(/.*)? so Nginx may not be able to  modify the cache
+# /var/cache/nginx(/.*)? so Nginx may not be able to modify the cache
 - name: nginx | selinux cache context policy
   become: true
   sefcontext:


### PR DESCRIPTION
At some point in the history of the IDR the version of Nginx used stopped setting the correct SELinux context on its cache directory. This only becomes obvious when the cache directory is rsync-ed since the selinux context isn't copied (cloning a volume preserves the selinux metadata).

This should fix it.

Tag: `1.12.1`