### PR TITLE
websocketsonly parameter to block non-websocket requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Backend servers:
   - `dynamic`: If `True` lookup IP on every request, default `False` (only lookup at startup).
   - `cache_validity`: The time that an object should be cached for, if omitted caching is disabled for this backend
   - `websockets`: If `True` enable proxying of websockets, default `False`
+  - `websocketsonly`: If `True` only allow websocket requests, otherwise return HTTP status 400, default `False`
   - `read_timeout`: The proxy read timeout, optional
   - `host_header`: Optionally set the Host header, you shouldn't need to set this unless you're trying to work around bugs in applications
   - `maintenance_flag`: Name of an optional local flag file used to indicate the backend is undergoing maintenance, if this file exists `maintenance_uri` will be returned for this location with a `503` error

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Backend servers:
   - `dynamic`: If `True` lookup IP on every request, default `False` (only lookup at startup).
   - `cache_validity`: The time that an object should be cached for, if omitted caching is disabled for this backend
   - `websockets`: If `True` enable proxying of websockets, default `False`
-  - `websocketsonly`: If `True` only allow websocket requests, otherwise return HTTP status 400, default `False`
+  - `websocketsonly`: If `True` and `websockets: True` only allow websocket requests, otherwise return HTTP status 400, default `False`
   - `read_timeout`: The proxy read timeout, optional
   - `host_header`: Optionally set the Host header, you shouldn't need to set this unless you're trying to work around bugs in applications
   - `maintenance_flag`: Name of an optional local flag file used to indicate the backend is undergoing maintenance, if this file exists `maintenance_uri` will be returned for this location with a `503` error

--- a/molecule/default/files/etc-nginx/conf.d/proxy-default.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-default.conf
@@ -47,6 +47,13 @@ server {
     }
 
     location /cached {
+        if ($http_upgrade !~* websocket) {
+            return 400;
+        }
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
         proxy_pass http://omeroreadonly;
         proxy_redirect http://omeroreadonly $scheme://$server_name;
 
@@ -67,10 +74,6 @@ server {
         proxy_ignore_headers   "Set-Cookie" "Vary" "Expires";
         proxy_hide_header Set-Cookie;
 
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-
         proxy_read_timeout 86400;
 
         proxy_set_header Host $host;
@@ -79,9 +82,9 @@ server {
     }
 
     location /maintenance-test {
+
         proxy_pass http://other;
         proxy_redirect http://other $scheme://$server_name;
-
 
 
 

--- a/molecule/default/files/etc-nginx/conf.d/proxy-nocache.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-nocache.conf
@@ -46,9 +46,9 @@ server {
     }
 
     location /nocache {
+
         proxy_pass http://nocache;
         proxy_redirect http://nocache $scheme://$server_name;
-
 
 
         proxy_read_timeout 600;

--- a/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
@@ -42,6 +42,7 @@ server {
     }
 
     location /other/ {
+
         proxy_pass http://other/;
         proxy_redirect http://other/ $scheme://$server_name;
 
@@ -65,16 +66,15 @@ server {
 
 
 
-
     }
 
     location /limitget/ {
+
         limit_except GET HEAD {
             deny all;
         }
         proxy_pass http://other/;
         proxy_redirect http://other/ $scheme://$server_name;
-
 
 
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -40,6 +40,7 @@
           server: http://omeroreadonly
           cache_validity: 1d
           websockets: true
+          websocketsonly: true
           read_timeout: 86400
           host_header: "$host"
         - name: maintenance-test

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -129,6 +129,17 @@ server {
         proxy_redirect {{ item.server }} $scheme://$server_name;
 {%   endif %}
 
+{%   if item.websockets | default(False) %}
+{%     if item.websocketsonly | default(False) %}
+        if ($http_upgrade !~* websocket) {
+            return 400;
+        }
+{%     endif %}
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+{%   endif %}
+
 {%   if item.cache_validity | default(False) %}
         proxy_cache            $cache_zone_name;
 {%     if nginx_proxy_cache_key %}
@@ -164,12 +175,6 @@ server {
 {%     for item in nginx_proxy_cache_hide_headers %}
         proxy_hide_header {{ item }};
 {%     endfor %}
-{%   endif %}
-
-{%   if item.websockets | default(False) %}
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
 {%   endif %}
 
 {%   if 'read_timeout' in item %}

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -109,6 +109,17 @@ server {
 
 {% for item in (site.nginx_proxy_backends | default(nginx_proxy_backends)) %}
     location {{ item.location }} {
+{%   if item.websockets | default(False) %}
+{%     if item.websocketsonly | default(False) %}
+        if ($http_upgrade !~* websocket) {
+            return 400;
+        }
+{%     endif %}
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+{%   endif %}
+
 {%   if item.dynamic | default(False) %}
         # To force dynamic DNS lookups need to use a variable
         set $backend_{{ item.name }} "{{ item.server }}";
@@ -127,17 +138,6 @@ server {
 {%     endif %}
         proxy_pass {{ item.server }};
         proxy_redirect {{ item.server }} $scheme://$server_name;
-{%   endif %}
-
-{%   if item.websockets | default(False) %}
-{%     if item.websocketsonly | default(False) %}
-        if ($http_upgrade !~* websocket) {
-            return 400;
-        }
-{%     endif %}
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
 {%   endif %}
 
 {%   if item.cache_validity | default(False) %}


### PR DESCRIPTION
If Nginx is used to load-balance websocket connections to multiple OMERO servers and someone makes a non-websocket request to the location OMERO will drop the connection, leading Nginx to think the server has failed and therefore remove it from the loadbalancing pool.

This adds a new option `websocketsonly` which if set will insert a check into the proxied location (Looks for the [`Upgrade: websocket` header](https://tools.ietf.org/html/rfc6455#section-1.3)) so non-websocket requests result in a HTTP status `400` (Bad Request client error).

Since this is a new parameter if someone is using this to proxy a backend server that supports websockets and normal HTTP for the same location they won't be affected.

Tag: `1.13.0`
