### PR TITLE
nginx_proxy_systemd_setup to disable running Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Additional custom configuration:
 - `nginx_proxy_conf_http`: Additional directives to be added to top-level `http` context
 - `nginx_proxy_additional_maps`: List of custom Nginx maps for use in other custom configuration
 - `nginx_proxy_additional_directives`: List of additional directives to be added to the proxy `server` context
+- `nginx_proxy_systemd_setup`: Start/restart nginx using systemd, default `true`, if you want to manage Nginx yourself set this to `false`
 
 
 Role Variables: Multiple sites

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,3 +191,6 @@ nginx_proxy_additional_maps: []
 #   mapvalues:
 #     - default value0
 #     - key1 value1
+
+# Start/restart nginx using systemd
+nginx_proxy_systemd_setup: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,4 @@
   service:
     name: nginx
     state: restarted
+  when: nginx_proxy_systemd_setup

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,5 @@ galaxy_info:
 dependencies:
   - role: ome.selinux_utils
   - role: ome.nginx
+    vars:
+      nginx_systemd_setup: "{{ nginx_proxy_systemd_setup }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,3 +30,4 @@
     enabled: true
     name: nginx
     state: started
+  when: nginx_proxy_systemd_setup


### PR DESCRIPTION
This is useful if you want to use the configuration from this role but run Nginx separately.

Tag: new feature `1.15.0`