### PR TITLE
Run restorecon in multithreaded mode

### DIFF
--- a/tasks/nginx-selinux.yml
+++ b/tasks/nginx-selinux.yml
@@ -31,7 +31,7 @@
 - name: nginx | restore cache context
   become: true
   command: >-
-    /usr/sbin/restorecon -R -v
+    /usr/sbin/restorecon -R -v -T 0
     {{ ansible_check_mode | ternary('-n', '') }}
     {{ nginx_proxy_cache_parent_path }}
   register: result


### PR DESCRIPTION
In the context of a production IDR deployment where the Nginx cache is restored from a previous production environment, the restorecon task is one of the biggest bottlenecks of the execution given the number of files - in the order of millions.
This change sets the restorecon multithreaded option to 0 to create as many threads as there are available CPU cores.