### PR TITLE
Change include: to include_tasks: for compatibility with ansible 2.18

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for roles/nginx-proxy
 
-- include: pre-tasks.yml
+- include_tasks: pre-tasks.yml
 
 - name: nginx | main config
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,20 +12,20 @@
   notify:
     - restart nginx
 
-- include: nginx-selinux.yml
+- include_tasks: nginx-selinux.yml
   when: selinux_enabled
 
-- include: nginx-additional.yml
+- include_tasks: nginx-additional.yml
 
-- include: nginx-cache.yml
+- include_tasks: nginx-cache.yml
 
-- include: nginx-websockets.yml
+- include_tasks: nginx-websockets.yml
 
-- include: nginx-redirects.yml
+- include_tasks: nginx-redirects.yml
 
-- include: nginx-streams.yml
+- include_tasks: nginx-streams.yml
 
-- include: nginx-proxy-sites.yml
+- include_tasks: nginx-proxy-sites.yml
 
 - name: nginx | start service
   become: true


### PR DESCRIPTION
To avoid the following error:

ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was rem
oved from ansible-core in a release after 2023-05-16. Please update your playbooks.                                           