### PR TITLE
revert seport and sefcontext

### DIFF
--- a/tasks/nginx-selinux.yml
+++ b/tasks/nginx-selinux.yml
@@ -11,7 +11,7 @@
 # This may not work if the port already has a different setype assigned to it
 - name: nginx | stream selinux ports
   become: true
-  ansible.posix.seport:
+  community.general.seport:
     ports: "{{ item.port }}"
     proto: tcp
     setype: http_port_t
@@ -22,7 +22,7 @@
 # /var/cache/nginx(/.*)? so Nginx may not be able to modify the cache
 - name: nginx | selinux cache context policy
   become: true
-  ansible.posix.sefcontext:
+  community.general.sefcontext:
     target: >-
       {{ nginx_proxy_cache_parent_path | regex_replace('\\/$', '') }}(/.*)?
     setype: httpd_cache_t


### PR DESCRIPTION
Sorry @pwalczysko , had to revert some changes. In contrast to `seboolean`, `seport` and `sefcontext` are still in `community.general`, of course... until they will totally unexpectedly move somewhere else too.

